### PR TITLE
Allow partitive of when referring to cheese slices

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ test.
 Okay, now, lets say we wanted to make our grilled cheese a little more exciting
 and add a couple of cheeses, `cheddar`, `mozzarella`, and `pepper jack`.
 
-To pass the second test, inside the `li` of `4 slices of cheese`, add a nested
+To pass the second test, inside the `li` of `4 slices cheese`, add a nested
 unordered list that lists out the three types of cheese.
 
 If your first two tests are passing, great! It's time to talk about another type

--- a/spec/list_tags_spec.rb
+++ b/spec/list_tags_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'index.html' do
     children = ul.children.select {|child| child.name == "li"}
     expect(children.length).to be >= 3, "Your <ul> tag needs at least three <li> tags, one for each ingredient"
     expect(children[0].text).to match(/2 slices of bread/)
-    expect(children[1]).to match(/4 slices cheese/)
+    expect(children[1]).to match(/4 slices.*cheese/)
     expect(children[2]).to match(/1 tbsp of butter/)
   end
 


### PR DESCRIPTION
The README used both "slices of cheese" as well as
"slices cheese." We will be consistent in saying
"slices cheese" but will test more loosely, thus
accepting either.